### PR TITLE
Change the timer implementation to fix behavior when app is backgrounded.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "icon": "./icon.png"
   },
   "devDependencies": {
-    "parcel": "^2.0.0"
+    "parcel": "^2.9.3"
   }
 }


### PR DESCRIPTION
By using dates instead of a counter we can get an accurate countdown.  Especially as modern versions of Chromium slow down intervals when the app is not in the foreground.

During my testing a 25 minute pomodoro could take anywhere between 30 and 40 minutes with the previous implementation as I didn't have Logseq in the foreground.

This implements standard tricks to make the first seconds display better aesthetically (like adding a few milliseconds to timers).

This should fix #11 